### PR TITLE
Deprecate the type tag extension (BEVE v2: variants as objects)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # BEVE - Binary Efficient Versatile Encoding
-Version 1
+Version 2
 
 *High performance, tagged binary data specification like JSON, MessagePack, CBOR, etc. But, designed for higher performance and scientific computing.*
 
 > See [Discussions](https://github.com/stephenberry/eve/discussions) for polls and active development on the specification.
+
+> **Version 2** deprecates the type tag extension (Extension 1). Variant-like structures are represented as ordinary objects rather than a positional index. See [6 - Extensions](#6---extensions).
 
 - Maps to and from JSON
 - Schema less, fully described, like JSON (can be used in documents)
@@ -273,11 +275,11 @@ Layout: `HEADER | SIZE | VALUE[0] | ... VALUE[N]`
 
 Extensions are considered to be a formal part of the BEVE specification, but are not expected to be as broadly implemented.
 
-Following the first three HEADER bits, the next five bits denote various extensions. These extensions are not expected to be implemented in every parser/serializer, but they provide convenient binary storage for more specialized use cases, such as variants, matrices, and complex numbers.
+Following the first three HEADER bits, the next five bits denote various extensions. These extensions are not expected to be implemented in every parser/serializer, but they provide convenient binary storage for more specialized use cases, such as matrices and complex numbers.
 
 ```c++
 0 -> data delimiter // for specs like Newline Delimited JSON
-1 -> type tag // for variant like structures
+1 -> type tag       // deprecated in Version 2 (see below); variants are ordinary objects
 2 -> matrices
 3 -> complex numbers
 ```
@@ -288,13 +290,15 @@ Used to separate chunks of data to match specifications like [NDJSON](http://ndj
 
 When converted to JSON this should add a new line (`'\n'`) character to the JSON.
 
-### 1 - Type Tag (Variants)
+### 1 - Type Tag (Variants) — Deprecated
 
-Expects a subsequent compressed unsigned integer to denote a type tag. A compressed SIZE indicator is used to efficiently store the tag.
+> **Deprecated in Version 2.** The type tag stored a variant as a positional integer index into an external list of types. Unlike every other BEVE construct, that index is not self-describing: it cannot be interpreted without the schema that defines the type ordering. Version 2 removes this special case and represents variant-like structures as ordinary objects instead.
 
-Layout : `HEADER | SIZE (i.e. type tag) | VALUE`
+Extension ID `1` is **reserved** and must not be reused. Encoders targeting Version 2 **must not** emit the type tag extension. Decoders **should** continue to read it when decoding Version 1 data, for backward compatibility.
 
-The converted JSON format should look like:
+**Variants in Version 2.** A variant is represented as an ordinary BEVE value, chosen exactly as it would be for JSON. BEVE imposes no discriminator convention; applications typically use a named tag field, such as `{"type": "circle", "radius": 5}` (internally tagged) or `{"type": "circle", "value": ...}` (adjacently tagged), matching whatever convention they already use for JSON. Because the result is a plain object, it needs no special decoder support and is as self-describing as any other BEVE value.
+
+**Legacy layout (Version 1, for decoders).** `HEADER | SIZE (i.e. type tag) | VALUE`, where `SIZE` is a compressed unsigned integer type tag and `VALUE` is any BEVE value. When converting legacy data to JSON, the historical mapping was:
 
 ```json
 {
@@ -303,9 +307,7 @@ The converted JSON format should look like:
 }
 ```
 
-The `"index"` should refer to an array of types, from zero to one less than the count of types.
-
-The `"value"` is any JSON value.
+The `"index"` referred to an array of types, from zero to one less than the count of types, and `"value"` was any JSON value.
 
 ### 2 - Matrices
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -44,7 +44,7 @@
         <div class="container">
             <h1>BEVE</h1>
             <p class="subtitle">Binary Efficient Versatile Encoding</p>
-            <p class="version">Version 1</p>
+            <p class="version">Version 2</p>
             <p class="tagline">High performance, tagged binary data specification like JSON, MessagePack, CBOR, etc. But, designed for higher performance and scientific computing.</p>
             <div class="cta-buttons">
                 <a href="#specification" class="btn btn-primary">Read Specification</a>
@@ -401,9 +401,9 @@ uint128_t     0b100'10'001</code></pre>
 
             <h3>6 - Extensions</h3>
             <p>Extensions are considered to be a formal part of the BEVE specification, but are not expected to be as broadly implemented.</p>
-            <p>Following the first three HEADER bits, the next five bits denote various extensions. These extensions are not expected to be implemented in every parser/serializer, but they provide convenient binary storage for more specialized use cases, such as variants, matrices, and complex numbers.</p>
+            <p>Following the first three HEADER bits, the next five bits denote various extensions. These extensions are not expected to be implemented in every parser/serializer, but they provide convenient binary storage for more specialized use cases, such as matrices and complex numbers.</p>
             <pre><code class="language-cpp">0 -&gt; data delimiter // for specs like Newline Delimited JSON
-1 -&gt; type tag // for variant like structures
+1 -&gt; type tag       // deprecated in Version 2 (see below); variants are ordinary objects
 2 -&gt; matrices
 3 -&gt; complex numbers</code></pre>
 
@@ -411,16 +411,18 @@ uint128_t     0b100'10'001</code></pre>
             <p>Used to separate chunks of data to match specifications like <a href="http://ndjson.org" target="_blank">NDJSON</a>.</p>
             <p>When converted to JSON this should add a new line (<code>'\n'</code>) character to the JSON.</p>
 
-            <h4>1 - Type Tag (Variants)</h4>
-            <p>Expects a subsequent compressed unsigned integer to denote a type tag. A compressed SIZE indicator is used to efficiently store the tag.</p>
-            <p>Layout: <code>HEADER | SIZE (i.e. type tag) | VALUE</code></p>
-            <p>The converted JSON format should look like:</p>
+            <h4>1 - Type Tag (Variants) — Deprecated</h4>
+            <div class="note">
+                <p><strong>Deprecated in Version 2.</strong> The type tag stored a variant as a positional integer index into an external list of types. Unlike every other BEVE construct, that index is not self-describing: it cannot be interpreted without the schema that defines the type ordering. Version 2 removes this special case and represents variant-like structures as ordinary objects instead.</p>
+            </div>
+            <p>Extension ID <code>1</code> is <strong>reserved</strong> and must not be reused. Encoders targeting Version 2 <strong>must not</strong> emit the type tag extension. Decoders <strong>should</strong> continue to read it when decoding Version 1 data, for backward compatibility.</p>
+            <p><strong>Variants in Version 2.</strong> A variant is represented as an ordinary BEVE value, chosen exactly as it would be for JSON. BEVE imposes no discriminator convention; applications typically use a named tag field, such as <code>{"type": "circle", "radius": 5}</code> (internally tagged) or <code>{"type": "circle", "value": ...}</code> (adjacently tagged), matching whatever convention they already use for JSON. Because the result is a plain object, it needs no special decoder support and is as self-describing as any other BEVE value.</p>
+            <p><strong>Legacy layout (Version 1, for decoders).</strong> <code>HEADER | SIZE (i.e. type tag) | VALUE</code>, where <code>SIZE</code> is a compressed unsigned integer type tag and <code>VALUE</code> is any BEVE value. When converting legacy data to JSON, the historical mapping was:</p>
             <pre><code class="language-json">{
   "index": 0,
   "value": "the JSON value"
 }</code></pre>
-            <p>The <code>"index"</code> should refer to an array of types, from zero to one less than the count of types.</p>
-            <p>The <code>"value"</code> is any JSON value.</p>
+            <p>The <code>"index"</code> referred to an array of types, from zero to one less than the count of types, and <code>"value"</code> was any JSON value.</p>
 
             <h4>2 - Matrices</h4>
             <p>Matrices can be stored as object or array types. However, this tag provides a more compact mechanism to introspect matrices.</p>

--- a/docs/proposals.html
+++ b/docs/proposals.html
@@ -83,7 +83,7 @@
             <p>This is a BEVE <strong>Extension</strong> (<code>HEADER</code> top 3 bits = <code>6</code>).</p>
             <p>Within the extension space, <strong>id = 4</strong> denotes <em>Time (timestamps)</em>.</p>
             <div class="note">
-                <p>Existing ids: 0=data delimiter, 1=type tag, 2=matrices, 3=complex numbers.<br>
+                <p>Existing ids: 0=data delimiter, 1=type tag (deprecated in v2, reserved), 2=matrices, 3=complex numbers.<br>
                 New: <strong>4=time</strong></p>
             </div>
             <p>All multi-byte integers in this extension are <strong>little endian</strong>.</p>

--- a/golang/main.go
+++ b/golang/main.go
@@ -352,8 +352,8 @@ func (b *Beve) readValue() (interface{}, error) {
 	case 6: // extensions
 		extension := (header & 0b11111000) >> 3
 		switch extension {
-		case 1: // variants
-			_ = b.readCompressed() // Skip variant tag
+		case 1: // variants (deprecated in v2 - read for backward compatibility with v1 data)
+			_ = b.readCompressed() // Skip the legacy type tag
 			return b.readValue()
 		case 2: // matrices
 			layout := b.buffer[b.cursor] & 0b00000001

--- a/javascript/beve.js
+++ b/javascript/beve.js
@@ -259,8 +259,8 @@
                     {
                         const extension = (header & 0b11111000) >> 3;
                         switch (extension) {
-                            case 1: // variants
-                                read_compressed(); // Skipping variant tag
+                            case 1: // variants (deprecated in v2 - read for backward compatibility with v1 data)
+                                read_compressed(); // Skip the legacy type tag
                                 return read_value();
                             case 2: // matrices
                                 const layout = buffer[cursor++] & 0b00000001;

--- a/javascript/beve_file.js
+++ b/javascript/beve_file.js
@@ -224,8 +224,8 @@ function read_value(fid) {
             {
                 const extension = (header[0] & 0b11111000) >> 3;
                 switch (extension) {
-                    case 1: // variants
-                        read_compressed(fid); // Skipping variant tag
+                    case 1: // variants (deprecated in v2 - read for backward compatibility with v1 data)
+                        read_compressed(fid); // Skip the legacy type tag
                         return read_value(fid);
                     case 2: // matrices
                         const layout = fs.readSync(fid, Buffer.alloc(1), 0, 1, null)[0] & 0b00000001;

--- a/matlab/load_beve.m
+++ b/matlab/load_beve.m
@@ -302,8 +302,8 @@ function data = read_value(fid)
         case 6 % extensions
             extension = bitshift(bitand(header, 0b11111000), -3);
             switch extension
-                case 1 % variants
-                    read_compressed(fid);
+                case 1 % variants (deprecated in v2 - read for backward compatibility with v1 data)
+                    read_compressed(fid); % skip the legacy type tag
                     data = read_value(fid);
                 case 2 % matrices
                     layout = bitand(fread(fid, 1, '*uint8', 'l'), 0b00000001);

--- a/matlab/load_beve_field.m
+++ b/matlab/load_beve_field.m
@@ -227,8 +227,8 @@ function skip_value(fid)
         case 6 % extension
             extension = bitshift(bitand(header, 0b11111000), -3);
             switch extension
-                case 1 % variant
-                    read_compressed(fid);
+                case 1 % variant (deprecated in v2 - read for backward compatibility with v1 data)
+                    read_compressed(fid); % skip the legacy type tag
                     skip_value(fid);
                 case 2 % matrix
                     fseek(fid, 1, 'cof'); % matrix header byte
@@ -537,8 +537,8 @@ function data = read_value(fid)
         case 6 % extension
             extension = bitshift(bitand(header, 0b11111000), -3);
             switch extension
-                case 1 % variant
-                    read_compressed(fid);
+                case 1 % variant (deprecated in v2 - read for backward compatibility with v1 data)
+                    read_compressed(fid); % skip the legacy type tag
                     data = read_value(fid);
                 case 2 % matrix
                     layout = bitand(fread(fid, 1, '*uint8', 'l'), 0b00000001);

--- a/matlab/write_beve.m
+++ b/matlab/write_beve.m
@@ -177,10 +177,10 @@ function write_value(fid, value)
     elseif isstring(value) && length(value) == 1
         % Handle single MATLAB string (convert to char)
         write_value(fid, char(value));
-    elseif isstruct(value) && isfield(value, 'tag') && isfield(value, 'value') && numel(fieldnames(value)) == 2
-        % Handle variant (Extension 1 - Type Tag)
-        write_variant(fid, value.tag, value.value);
     elseif isstruct(value)
+        % Structs (including variant-style {tag, value} structs) serialize as
+        % ordinary objects. The Version 1 type tag extension for variants is
+        % deprecated and is no longer emitted.
         header = uint8(3);
         key_type = 0;  % Assuming keys are always strings
         header = bitor(header, bitshift(key_type, 3));
@@ -197,19 +197,6 @@ function write_value(fid, value)
     else
         error('Unsupported data type: %s', class(value));
     end
-end
-
-function write_variant(fid, tag, value)
-    % Write a variant (Extension 1 - Type Tag)
-    header = uint8(6);  % Type 6 = extensions
-    header = bitor(header, bitshift(1, 3));  % Extension 1 = type tag (variant)
-    write_byte(fid, header);
-    
-    % Write the type tag as a compressed unsigned integer
-    write_compressed(fid, tag);
-    
-    % Write the value
-    write_value(fid, value);
 end
 
 function write_complex(fid, value)

--- a/proposals/Deprecate Type Tag Extension Proposal.md
+++ b/proposals/Deprecate Type Tag Extension Proposal.md
@@ -1,0 +1,97 @@
+# BEVE Proposal: Deprecate the Type Tag Extension (Variants as Objects)
+
+**Status:** Working Draft
+**Targets:** BEVE Version 2
+
+## Motivation
+
+BEVE is a schema-less, fully self-describing format. Like JSON, a BEVE message can be understood without any external type information: an object carries its keys, a number carries its width and signedness, a matrix carries its layout and extents, a complex number carries its numeric type. This property is what allows BEVE to map cleanly to and from JSON and to be used for standalone documents.
+
+The **type tag** extension (Extension 1) is the one place the format departs from this principle.
+
+```
+HEADER(0x0E) | SIZE (i.e. type tag) | VALUE
+```
+
+The type tag is a **positional integer index** into an ordered list of alternative types. Unlike every other construct in BEVE, that index carries no self-contained meaning. A type tag of `3` is uninterpretable without the external schema that says "index 3 is `SomeType`". A decoder converting the message to JSON cannot do better than emit an opaque:
+
+```json
+{ "index": 3, "value": "the JSON value" }
+```
+
+This has three practical consequences:
+
+1. **It is not self-describing.** The one property that defines BEVE is lost precisely where a discriminated union most needs to be understood.
+2. **It does not match how variants appear in JSON.** Real-world tagged unions use a named discriminator (`{"type":"circle","radius":5}`), not a positional index. The `{"index","value"}` mapping is an artifact of the binary encoding, not something a JSON producer would ever choose.
+3. **It is brittle across schema evolution.** Reordering, inserting, or removing an alternative silently changes the meaning of every previously-encoded index.
+
+Notably, the other extensions do **not** share this problem. Matrices (Extension 2) and complex numbers (Extension 3) are fully self-describing, so the argument below applies only to the type tag.
+
+## Design Goals
+
+1. **Restore self-description.** Variant-like structures should be as self-describing as any other BEVE value.
+2. **Restore JSON equivalence.** The variant representation should map to and from JSON with no special-case rules.
+3. **No new binary machinery.** Solve the problem by removing an encoding, not adding one.
+4. **Do not impose a convention.** BEVE should not mandate a discriminator key or force a particular JSON shape, any more than JSON itself does. The choice belongs to the application and its schema.
+5. **Smooth migration.** Existing BEVE Version 1 data containing type tags must remain readable.
+
+## The Change
+
+### Variants Are Ordinary Values
+
+BEVE Version 2 introduces **no special encoding for variants**. A discriminated union is represented as an ordinary BEVE value, chosen by the application exactly as it would choose the JSON representation. In the common case this is a BEVE object whose members include a discriminator, but BEVE imposes no requirement on the shape.
+
+Because the result is a plain object (or plain value), it requires no special decoder support: every BEVE reader already handles it, and it is self-describing to exactly the degree the application's own convention is. Variant semantics live at the application/schema layer, precisely as they do in JSON.
+
+### Deprecate Extension 1
+
+Extension 1 (type tag) is **deprecated** in BEVE Version 2.
+
+- The extension ID `1` is **reserved**. It **must not** be reused for any future extension.
+- Encoders targeting Version 2 **must not** emit the type tag extension.
+- Decoders **should** continue to accept and decode the type tag extension when reading Version 1 data, to preserve backward compatibility. A decoder that does not require legacy support **may** reject it as an unknown/deprecated extension.
+
+## Representing Variants in Practice (Informative)
+
+This section is **non-normative**. BEVE does not mandate any of the following; it documents the conventions applications commonly use so that BEVE and JSON representations line up. Because BEVE objects map 1:1 to JSON objects, whatever convention an application already uses for JSON tagged unions works unchanged in BEVE.
+
+The two widely-used shapes are:
+
+**Internally tagged** — the discriminator is a member of the alternative's own object. Requires the alternative to serialize as an object.
+
+```json
+{ "type": "circle", "radius": 5 }
+```
+
+**Adjacently tagged** — the discriminator and payload are separate members. Works for any alternative type, including non-objects.
+
+```json
+{ "type": "circle", "value": { "radius": 5 } }
+```
+
+The discriminator **key** (`"type"`, `"tag"`, `"kind"`, ...) is chosen by the application. The discriminator **value** is best given as a **string** naming the alternative when the goal is a self-describing, interchange-friendly message; an integer discriminator works but reintroduces the schema dependence this proposal set out to remove, so it is discouraged for interchange.
+
+Where a schema is available, an application may also deduce the active alternative **structurally** from the value itself, for example from the set of object keys present, or, in BEVE specifically, from the value's type header (BEVE distinguishes `int32` from `int64` from `float64` in-band, which JSON cannot). This is an application-level concern; BEVE neither requires nor precludes it.
+
+## JSON Mapping
+
+There is no special mapping. A variant encoded as an object maps to JSON as any object does, and back again. The Version 1 `{"index","value"}` mapping is removed along with the extension.
+
+## Backward Compatibility
+
+- **Forward direction is free.** A Version 2 variant is an ordinary BEVE value, so it is already valid Version 1 BEVE. A Version 1 decoder reads it with no error and no special handling.
+- **Reverse direction is covered by the read rule.** The only construct a Version 2 decoder may encounter that a Version 1 producer emitted is the type tag extension itself; per the deprecation rule above, decoders should continue to read it.
+- **No version signal is required for interop.** Because the Version 2 variant encoding is a strict subset of existing Version 1 value types, a producer need not advertise a version for a consumer to read its variants. Where explicit version negotiation is desired for other reasons, the [Framing Header](Framing%20Header%20Proposal.md) extension (Extension 5, version byte) provides it; a Version 2 producer may set its `VERSION` byte to `2`.
+
+## Migration
+
+- **Producers:** replace type-tag output with the object (or value) the application uses for the corresponding JSON. No BEVE-specific encoding is needed.
+- **Consumers:** retain the existing type-tag decode path so previously-serialized Version 1 data continues to load; route newly-produced data through the ordinary object path.
+
+## Impact on Implementations
+
+Implementations that today special-case variants in their BEVE reader/writer will move that logic to the same object path they already use for JSON tagged unions, unifying two mechanisms into one. Readers gain (or reuse) an ordinary object-parsing path for variants and keep a legacy branch for the deprecated extension. The reference C++ implementation, [Glaze](https://github.com/stephenberry/glaze), already provides the target behavior through its JSON variant support (a named discriminator plus per-alternative ids, with structural fallback).
+
+## Summary
+
+BEVE Version 2 deprecates the type tag extension (Extension 1) and represents variant-like structures as ordinary BEVE values, chosen by the application exactly as for JSON. This restores full self-description and JSON equivalence, adds no new binary machinery, and imposes no discriminator convention. Extension ID 1 is reserved and must not be reused; encoders must not emit it, while decoders should continue to read it for backward compatibility with Version 1 data.

--- a/python/load_beve.py
+++ b/python/load_beve.py
@@ -140,7 +140,7 @@ def load_beve(filename):
                 data.append(read_value(fid))
         elif type_val == 6:  # extensions
             extension = np.bitwise_and(header, 0b11111000) >> 3
-            if extension == 1: # variants
+            if extension == 1: # variants (deprecated in v2 - read for backward compatibility with v1 data)
                 read_compressed(fid)
                 data = read_value(fid)
             elif extension == 2:  # matrices


### PR DESCRIPTION
## Summary

Deprecates the **type tag extension** (extension id 1) and moves BEVE to **Version 2**, where variant-like structures are represented as ordinary objects rather than a positional index.

Motivated by [discussion #30](https://github.com/beve-org/beve/discussions/30). The type tag encoded a variant as a positional integer index into an external list of types. Unlike every other BEVE construct (objects carry their keys, matrices carry layout/extents, complex numbers carry their numeric type), that index is **not self-describing**: it can't be interpreted without the schema that defines the type ordering. That's the one place BEVE stopped being schema-less and JSON-equivalent, and it forced the awkward `{"index","value"}` JSON mapping that matches no real tagged-union convention.

## Design decisions

- **Non-prescriptive.** v2 does not mandate a discriminator key or a specific variant shape. A variant is just an ordinary object, encoded exactly as the application would for JSON. Internal/adjacent tagging are shown only as informative examples.
- **Deprecate, but read legacy.** Encoders **must not** emit extension 1. Decoders **should** continue to **read** it for backward compatibility with v1 data. Extension id 1 stays reserved and is never reused.
- **Forward-compatible for free.** A v2 variant is already valid v1 BEVE (it's just an object), so v1 decoders read v2 output with no changes.

## Changes

- **Spec** (`README.md`, `docs/index.html`): bump to Version 2, deprecate extension 1 in the list and its subsection, document variants-as-objects, and keep the legacy layout documented for decoder authors. Marked the tag `reserved` on the Time-extension proposal page (`docs/proposals.html`).
- **MATLAB encoder** (`matlab/write_beve.m`): the only encoder that emitted the extension. Removed the `{tag, value}` special-case and `write_variant`; such structs now serialize as ordinary objects.
- **Decoders** (`javascript/beve.js`, `javascript/beve_file.js`, `matlab/load_beve.m`, `matlab/load_beve_field.m`, `python/load_beve.py`, `golang/main.go`): read path unchanged; comments mark extension 1 as deprecated/legacy.
- **Proposal**: `proposals/Deprecate Type Tag Extension Proposal.md`.

## Verification

- JavaScript test suite: 87/87 pass.
- `python -m py_compile` clean; Go `gofmt` clean; no dangling `write_variant` references.
- Reviewed for MATLAB dispatch-ordering hazards (a scalar `{tag,value}` struct correctly falls through to the object writer; the matrix branch is guarded by `~isstruct`), decoder read-path integrity, README/HTML consistency, anchor correctness, and RFC-style MUST/SHOULD wording.

## Follow-up (not in this PR)

The reference C++ implementation ([Glaze](https://github.com/stephenberry/glaze)) still emits/reads the index-based extension for BEVE variants. Aligning it (object-based write + read using its existing JSON discriminator machinery, structural auto-deduction for untagged variants, legacy read retained) is a separate change.
